### PR TITLE
fixing selecting matcher and adding tests for it

### DIFF
--- a/src/main/java/nl/fd/hamcrest/jsoup/ElementWithChild.java
+++ b/src/main/java/nl/fd/hamcrest/jsoup/ElementWithChild.java
@@ -25,10 +25,7 @@ public class ElementWithChild extends TypeSafeDiagnosingMatcher<Element> {
     protected boolean matchesSafely(Element parent, Description description) {
         Elements elements = parent.select(cssSelector);
         if (elements.isEmpty()) {
-            description
-                    .appendText("expected element to have at least one child matching selector ")
-                    .appendValue(cssSelector)
-                    .appendText(" but nothing found.");
+            description.appendText("no matching child was found");
 
             return false;
         }
@@ -37,7 +34,8 @@ public class ElementWithChild extends TypeSafeDiagnosingMatcher<Element> {
 
     @Override
     public void describeTo(Description description) {
-        description.appendText(" has child selected by ").appendValue(cssSelector);
+        description.appendText("to have at least one child matching selector ")
+                .appendValue(cssSelector);
     }
 
     @Factory

--- a/src/main/java/nl/fd/hamcrest/jsoup/ElementWithData.java
+++ b/src/main/java/nl/fd/hamcrest/jsoup/ElementWithData.java
@@ -28,7 +28,7 @@ public class ElementWithData extends TypeSafeDiagnosingMatcher<Element> {
     @Override
     protected boolean matchesSafely(Element item, Description mismatchDescription) {
         if (!matcher.matches(item.data())) {
-            mismatchDescription.appendText(" data ");
+            mismatchDescription.appendText("data ");
             matcher.describeMismatch(item.data(), mismatchDescription);
             return false;
         }
@@ -37,7 +37,7 @@ public class ElementWithData extends TypeSafeDiagnosingMatcher<Element> {
 
     @Override
     public void describeTo(Description description) {
-        description.appendText("element with data ");
+        description.appendText("element to have data matching ");
         matcher.describeTo(description);
     }
 }

--- a/src/main/java/nl/fd/hamcrest/jsoup/Selecting.java
+++ b/src/main/java/nl/fd/hamcrest/jsoup/Selecting.java
@@ -7,16 +7,14 @@ import org.hamcrest.TypeSafeDiagnosingMatcher;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 
-import java.util.List;
-
 /**
-*
-*/
+ *
+ */
 public class Selecting extends TypeSafeDiagnosingMatcher<Element> {
     private final String cssExpression;
-    private final Matcher<Iterable<Element>> selectionMatcher;
+    private final Matcher<Iterable<? super Element>> selectionMatcher;
 
-    private Selecting(String cssExpression, Matcher<Iterable<Element>> selectionMatcher) {
+    private Selecting(String cssExpression, Matcher<Iterable<? super Element>> selectionMatcher) {
         this.cssExpression = cssExpression;
         this.selectionMatcher = selectionMatcher;
     }
@@ -25,13 +23,14 @@ public class Selecting extends TypeSafeDiagnosingMatcher<Element> {
      * Creates a {@link org.hamcrest.Matcher} for a JSoup {@link org.jsoup.nodes.Element} that has a list of child nodes
      * matching the specified cssExpression that are matched by the specified elementsMatcher.
      *
-     * @param cssExpression The Jsoup CSS expression used to selected a list of child nodes
+     * @param cssExpression   The Jsoup CSS expression used to selected a list of child nodes
      * @param elementsMatcher the matcher that the selected child nodes will be matched against
+     *
      * @return a {@link org.hamcrest.Matcher} for a JSoup {@link org.jsoup.nodes.Element}
      */
     @Factory
     @SuppressWarnings("unchecked")
-    public static Matcher<Element> selecting(final String cssExpression, final Matcher<Iterable<Element>> elementsMatcher) {
+    public static Matcher<Element> selecting(final String cssExpression, final Matcher<Iterable<? super Element>> elementsMatcher) {
         return new Selecting(cssExpression, elementsMatcher);
     }
 
@@ -40,9 +39,8 @@ public class Selecting extends TypeSafeDiagnosingMatcher<Element> {
         Elements elements = item.select(cssExpression);
 
         if (!selectionMatcher.matches(elements)) {
-            mismatchDescription.appendText("expected element with children selected by ").appendValue(cssExpression).
-                    appendText(" matching ").appendDescriptionOf(selectionMatcher)
-                    .appendText(" but ");
+            mismatchDescription.appendText("has children selected by ").appendValue(cssExpression)
+                    .appendText(" do not match ");
             selectionMatcher.describeMismatch(elements, mismatchDescription);
             return false;
         }
@@ -51,6 +49,6 @@ public class Selecting extends TypeSafeDiagnosingMatcher<Element> {
 
     @Override
     public void describeTo(Description description) {
-        description.appendText(" has children selected by ").appendValue(cssExpression).appendText(" matching ").appendDescriptionOf(selectionMatcher);
+        description.appendText("to have children selected by ").appendValue(cssExpression).appendText(" matching ").appendDescriptionOf(selectionMatcher);
     }
 }

--- a/src/main/java/nl/fd/hamcrest/jsoup/Selecting.java
+++ b/src/main/java/nl/fd/hamcrest/jsoup/Selecting.java
@@ -39,7 +39,9 @@ public class Selecting extends TypeSafeDiagnosingMatcher<Element> {
         Elements elements = item.select(cssExpression);
 
         if (!selectionMatcher.matches(elements)) {
-            mismatchDescription.appendText("has children selected by ").appendValue(cssExpression)
+            mismatchDescription
+                    .appendText("has children selected by ")
+                    .appendValue(cssExpression)
                     .appendText(" do not match ");
             selectionMatcher.describeMismatch(elements, mismatchDescription);
             return false;

--- a/src/test/java/nl/fd/hamcrest/jsoup/test/ElementWithChildTest.java
+++ b/src/test/java/nl/fd/hamcrest/jsoup/test/ElementWithChildTest.java
@@ -1,6 +1,5 @@
 package nl.fd.hamcrest.jsoup.test;
 
-import nl.fd.hamcrest.jsoup.ElementWithChild;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.StringDescription;
@@ -8,6 +7,7 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Element;
 import org.junit.Test;
 
+import static nl.fd.hamcrest.jsoup.ElementWithChild.hasChild;
 import static org.junit.Assert.*;
 
 /**
@@ -18,7 +18,7 @@ public class ElementWithChildTest {
     @Test
     public void testMatches_match() {
         // Given
-        Matcher<Element> hasChild = ElementWithChild.hasChild(".second-div a[href=testvalue]");
+        Matcher<Element> hasChild = hasChild(".second-div a[href=testvalue]");
         Element body = Jsoup.parse(
                 "<body>" +
                         "<div class=\"first-div\"></div>" +
@@ -40,7 +40,7 @@ public class ElementWithChildTest {
     @Test
     public void testMatches_mismatch() {
         // Given
-        Matcher<Element> hasChild = ElementWithChild.hasChild(".first-div a[href=testvalue]");
+        Matcher<Element> hasChild = hasChild(".first-div a[href=testvalue]");
         Element body = Jsoup.parse(
                 "<body>" +
                         "<div class=\"first-div\"></div>" +
@@ -63,7 +63,7 @@ public class ElementWithChildTest {
     @Test
     public void testDescribeMismatch_noMismatch() throws Exception {
         // Given
-        Matcher<Element> selecting = ElementWithChild.hasChild("p");
+        Matcher<Element> selecting = hasChild("p");
         Element element = Jsoup.parse("<div><p>Some <a href=\"abc\">linked</a> text</p></div>").body().children().first();
         Description description = new StringDescription();
 
@@ -78,17 +78,25 @@ public class ElementWithChildTest {
     @Test
     public void testDescribeMismatch() throws Exception {
         // Given
-        Matcher<Element> selecting = ElementWithChild.hasChild("span");
+        Matcher<Element> selecting = hasChild("span");
         Element element = Jsoup.parse("<div><p>Some <a href=\"abc\">linked</a> text</p></div>").body().children().first();
-        Description description = new StringDescription();
+        Description actualDescription = new StringDescription();
 
         // When
-        selecting.describeMismatch(element, description);
+        selecting.describeMismatch(element, actualDescription);
+
+        Description expectationDescription = new StringDescription();
+        selecting.describeTo(expectationDescription);
 
         // Then
         assertEquals(
-                "expected element to have at least one child matching selector \"span\" but nothing found.",
-                description.toString()
+                "to have at least one child matching selector \"span\"",
+                expectationDescription.toString()
+        );
+
+        assertEquals(
+                "no matching child was found",
+                actualDescription.toString()
         );
     }
 

--- a/src/test/java/nl/fd/hamcrest/jsoup/test/ElementWithChildTest.java
+++ b/src/test/java/nl/fd/hamcrest/jsoup/test/ElementWithChildTest.java
@@ -81,11 +81,10 @@ public class ElementWithChildTest {
         Matcher<Element> selecting = hasChild("span");
         Element element = Jsoup.parse("<div><p>Some <a href=\"abc\">linked</a> text</p></div>").body().children().first();
         Description actualDescription = new StringDescription();
+        Description expectationDescription = new StringDescription();
 
         // When
         selecting.describeMismatch(element, actualDescription);
-
-        Description expectationDescription = new StringDescription();
         selecting.describeTo(expectationDescription);
 
         // Then

--- a/src/test/java/nl/fd/hamcrest/jsoup/test/ElementWithDataTest.java
+++ b/src/test/java/nl/fd/hamcrest/jsoup/test/ElementWithDataTest.java
@@ -1,25 +1,21 @@
 package nl.fd.hamcrest.jsoup.test;
 
-import nl.fd.hamcrest.jsoup.ElementWithData;
-import nl.fd.hamcrest.jsoup.ElementWithName;
 import org.hamcrest.Matcher;
 import org.hamcrest.StringDescription;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Element;
 import org.junit.Test;
 
+import static nl.fd.hamcrest.jsoup.ElementWithData.hasData;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 public class ElementWithDataTest {
 
     @Test
     public void testWithData_describeMismatch_no_mismatch() {
         // Given
-        Matcher<Element> matcher = ElementWithData.hasData(containsString("var i = 1;"));
+        Matcher<Element> matcher = hasData(containsString("var i = 1;"));
         Element element = Jsoup.parse("<body><script>var i = 1;</script></body>").body().children().first();
         StringDescription description = new StringDescription();
 
@@ -33,7 +29,7 @@ public class ElementWithDataTest {
     @Test
     public void testWithData_describeMismatch_matcher() {
         // Given
-        Matcher<Element> matcher = ElementWithData.hasData(containsString("var i = 2;"));
+        Matcher<Element> matcher = hasData(containsString("var i = 2;"));
         Element element = Jsoup.parse("<body><script>var i = 1;</script></body>").body().children().first();
         StringDescription description = new StringDescription();
 
@@ -41,20 +37,21 @@ public class ElementWithDataTest {
         matcher.describeMismatch(element, description);
 
         // Then
-        assertEquals(" data was \"var i = 1;\"", description.toString());
+        assertEquals("data was \"var i = 1;\"", description.toString());
     }
 
     @Test
     public void testWithData_describeTo() {
         // Given
-        Matcher<Element> matcher = ElementWithData.hasData(containsString("var i = 1;"));
+        Matcher<Element> matcher = hasData(containsString("var i = 1;"));
         StringDescription description = new StringDescription();
 
         // When
         matcher.describeTo(description);
 
         // Then
-        assertEquals("element with data a string containing \"var i = 1;\"", description.toString());
+        assertEquals("element to have data matching a string containing \"var i = 1;\"", description.toString());
+
     }
 
 }

--- a/src/test/java/nl/fd/hamcrest/jsoup/test/SelectingTest.java
+++ b/src/test/java/nl/fd/hamcrest/jsoup/test/SelectingTest.java
@@ -1,6 +1,5 @@
 package nl.fd.hamcrest.jsoup.test;
 
-import nl.fd.hamcrest.jsoup.Selecting;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.StringDescription;
@@ -9,13 +8,67 @@ import org.jsoup.nodes.Element;
 import org.junit.Test;
 
 import static nl.fd.hamcrest.jsoup.ElementWithText.hasText;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static nl.fd.hamcrest.jsoup.Selecting.selecting;
+import static org.hamcrest.core.IsCollectionContaining.hasItem;
+import static org.junit.Assert.*;
 
 /**
  * Unit tests for the Selecting class.
  */
 public class SelectingTest {
+
+    @Test
+    public void testMatches_match() throws Exception {
+        // Given
+        Matcher<Element> selected = selecting("p", hasItem(hasText("Some linked text")));
+        Element element = Jsoup.parse("<div><p>Some <a href=\"abc\">linked</a> text</p><p>Some unlinked text</p></div>").body().children().first();
+
+        // When
+        boolean matches = selected.matches(element);
+
+        // Then
+        assertTrue(matches);
+    }
+
+    @Test
+    public void testMatches_mismatch() throws Exception {
+        // Given
+        Matcher<Element> selected = selecting("p", hasItem(hasText("Some weird text")));
+        Element element = Jsoup.parse("<div><p>Some <a href=\"abc\">linked</a> text</p><p>Some unlinked text</p></div>").body().children().first();
+
+        // When
+        boolean matches = selected.matches(element);
+
+        // Then
+        assertFalse(matches);
+    }
+
+    @Test
+    public void testDescribeMismatch_noMismatch() throws Exception {
+        // Given
+        Matcher<Element> selected = selecting("p", hasItem(hasText("Some linked text")));
+        Element element = Jsoup.parse("<div><p>Some <a href=\"abc\">linked</a> text</p><p>Some unlinked text</p></div>").body().children().first();
+        Description description = new StringDescription();
+
+        // When
+        selected.describeMismatch(element, description);
+
+        // Then
+        assertEquals("", description.toString());
+    }
+
+    @Test
+    public void testDescribeMismatch() throws Exception {
+        // Given
+        Matcher<Element> selected = selecting("p", hasItem(hasText("Some weird text")));
+        Element element = Jsoup.parse("<div><p>Some <a href=\"abc\">linked</a> text</p><p>Some unlinked text</p></div>").body().children().first();
+        Description description = new StringDescription();
+
+        // When
+        selected.describeMismatch(element, description);
+
+        // Then
+        assertEquals("has children selected by \"p\" do not match expected element with text matching (is \"Some weird text\") but was \"Some linked text\", expected element with text matching (is \"Some weird text\") but was \"Some unlinked text\"", description.toString());
+    }
 
 }


### PR DESCRIPTION
fixes `selecting` matcher's wrong generic type which prevented similar assertions as following to be impossible:
```java
assertThat(parsedBody, selecting("[class=classname] ul li", hasSize(2)));
```

also does some message fixing in other selectors